### PR TITLE
Load references to databases at module loading

### DIFF
--- a/PIconnect/PIAF.py
+++ b/PIconnect/PIAF.py
@@ -62,16 +62,14 @@ class PIAFDatabase(object):
     """PIAFDatabase
 
     Context manager for connections to the PI Asset Framework database.
-
-    .. todo::
-
-        List databases at class loading and remove note in
-        :ref:`connect_piaf_database`.
     """
 
-    version = "0.1.0"
+    version = "0.2.0"
 
-    servers = {x.Name: {"server": x, "databases": {}} for x in AF.PISystems()}
+    servers = {
+        s.Name: {"server": s, "databases": {d.Name: d for d in s.Databases}}
+        for s in AF.PISystems()
+    }
     default_server = servers[AF.PISystems().DefaultPISystem.Name]
 
     def __init__(self, server=None, database=None):

--- a/PIconnect/PIAF.py
+++ b/PIconnect/PIAF.py
@@ -100,7 +100,10 @@ class PIAFDatabase(object):
         return self
 
     def __exit__(self, *args):
-        self.server.Disconnect()
+        pass
+        # Disabled disconnecting because garbage collection sometimes impedes
+        # connecting to another server later
+        # self.server.Disconnect()
 
     def __repr__(self):
         return "%s(\\\\%s\\%s)" % (

--- a/PIconnect/PIAF.py
+++ b/PIconnect/PIAF.py
@@ -64,7 +64,7 @@ class PIAFDatabase(object):
     Context manager for connections to the PI Asset Framework database.
     """
 
-    version = "0.2.0"
+    version = "0.1.1"
 
     servers = {
         s.Name: {"server": s, "databases": {d.Name: d for d in s.Databases}}

--- a/docs/tutorials/piaf.rst
+++ b/docs/tutorials/piaf.rst
@@ -115,5 +115,14 @@ following code.
     import PIconnect as PI
     print(list(PI.PIAFDatabase.servers.keys()))
 
-.. note:: The database names are currently not loaded until a connection to
-    the server is made, this will change in a future release.
+A list of the databases on a given server can be retrieved from the same
+:any:`PIAFDatabase.servers` attribute. Each item in the dictionary of servers
+is a dictionary with two items, :data:`server` and :data:`databases`. The
+first contains the raw server object from the SDK, while the :data:`databases`
+item is a dictionary of {name: object} pairs. So to get the databases for a
+given server you can use the following code:
+
+.. code-block:: python
+
+    import PIconnect as PI
+    print(list(PI.PIAFDatabase.servers["ServerName"]["databases"].keys()))

--- a/docs/tutorials/piaf.rst
+++ b/docs/tutorials/piaf.rst
@@ -23,7 +23,7 @@ as follows:
 
     with PI.PIAFDatabase() as database:
         for root in database.children.values():
-            print('Root element: {r}'.format(r=root))
+            print("Root element: {r}".format(r=root))
 
 The keys of the dictionary are the names of the elements inside. The following
 snippet first gets the first key in the dictionary, and the uses that to get
@@ -51,7 +51,7 @@ To get the data for the last 48 hours from a given attribute you need the
         key = next(iter(database.children))
         element = database.children[key]
         attribute = next(iter(element.attributes.values()))
-        data = attribute.recorded_values('*-48h', '*')
+        data = attribute.recorded_values("*-48h", "*")
         print(data)
 
 .. note:: Attributes on root elements within the database might not have
@@ -76,7 +76,7 @@ the latter element could be accessed directly as follows:
     import PIconnect as PI
 
     with PI.PIAFDatabase() as database:
-        element = database.descendant(r'Plant1\Outlet')
+        element = database.descendant(r"Plant1\Outlet")
 
 .. note:: Elements in the hierarchy are separated by a single backslash `\\`,
           use either raw strings (using the `r` prefix, as in the example
@@ -97,7 +97,7 @@ server and database as arguments to the :any:`PIAFDatabase` constructor.
 
     import PIconnect as PI
 
-    with PI.PIAFDatabase(server='ServerName', database='DatabaseName') as database:
+    with PI.PIAFDatabase(server="ServerName", database="DatabaseName") as database:
         print(database.server_name)
 
 .. note:: It is also possible to specify only server or database. When only


### PR DESCRIPTION
This feature not only loads the PI AF servers, but also the databases on those servers.