### PR TITLE
Add extra trigger for pull requests from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install black flake8 pytest wheel
+          python -m pip install flake8 pytest wheel
           python -m pip install codecov pytest-cov codacy-coverage
           python -m pip install .
-
-      - name: Check formatting with black
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          black --check --diff PIconnect
 
       - name: Lint with flake8
         run: |
@@ -60,3 +55,24 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage.xml
+
+  check_format:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install black
+
+      - name: Check formatting with black
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          black --check --diff PIconnect

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,6 @@ jobs:
         run: |
           pytest
 
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage.xml
-
   check_format:
     runs-on: windows-latest
 
@@ -76,3 +70,13 @@ jobs:
         run: |
           # stop the build if there are Python syntax errors or undefined names
           black --check --diff PIconnect
+
+      - name: Test with pytest
+        run: |
+          pytest
+
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install flake8 pytest wheel
+          python -m pip install pytest-cov
           python -m pip install .
 
       - name: Lint with flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install flake8 pytest wheel
-          python -m pip install codecov pytest-cov codacy-coverage
           python -m pip install .
 
       - name: Lint with flake8
@@ -70,6 +69,22 @@ jobs:
         run: |
           # stop the build if there are Python syntax errors or undefined names
           black --check --diff PIconnect
+
+  check_coverage:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install codecov pytest-cov codacy-coverage
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
     branches:
       - master
       - develop
+  pull_request_target:
+    branches:
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install codecov pytest-cov codacy-coverage
+          python -m pip install .
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Currently GitHub actions is configured to run the workflow from the incoming pull request. Therefore access tokens are not shared as a malicious contributor could change the configuration to publish the secret somewhere he has access to. This PR adds another trigger for the workflow for pull requests from forks, which uses the workflow configuration from target branch, which can be trusted.