### PR TITLE
Remove Python 2.7 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -41,8 +41,8 @@ System
 ------
 
 -   OS: \[e.g. Windows, Linux]
--   Python version: \[Python 2.7/ Python 3.6]
--   PIconnect version: \[e.g. 0.5.2]
+-   Python version: \[Python 3.x]
+-   PIconnect version: \[e.g. 0.10.0]
 
 Additional context
 ------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ name: Test PIconnect
 
 on:
   push:
-    branches: [develop, master]
+    branches: [develop, master, remove_python2_support]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [develop]
+    branches: [develop, remove_python2_support]
   schedule:
     - cron: "27 19 * * 3"
 
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [develop, master]
+    branches: [develop, master, remove_python2_support]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [develop]
+    branches: [develop, remove_python2_support]
   schedule:
     - cron: "18 19 * * 3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ profile = "black"
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39']
 include = '\.pyi?$'

--- a/setup.py
+++ b/setup.py
@@ -69,12 +69,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        # 'Programming Language :: Python :: 2',
-        "Programming Language :: Python :: 2.7",
         # 'Programming Language :: Python :: 3',
-        # 'Programming Language :: Python :: 3.3',
-        # 'Programming Language :: Python :: 3.4',
-        # "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,16 @@
 envlist =
     black, pylint, mypy
 
-    py27, py35, py36, py37, py38
+    py35, py36, py37, py38
 
 ; [travis]
 ; python =
-;     2.7: py27
 ;     3.7: py37
 ;     3.6: py36
 ;     3.5: py35
 
 [testenv]
 basepython =
-    py27: python2.7
     py35: python3.5
     py36: python3.6
     py37: python3.7


### PR DESCRIPTION
This PR will show the progress towards removing Python 2.7 support for now. Python 2 incompatible changes can be made against this branch, so we can merge those changes into `develop` once PIconnect 0.9 is released. 

Closes #579.