### PR TITLE
Load System module centrally to allow fallback

### DIFF
--- a/PIconnect/AFSDK.py
+++ b/PIconnect/AFSDK.py
@@ -6,13 +6,11 @@ import os
 import sys
 import typing
 
-import pythonnet
-
-__all__ = ["AF", "AF_SDK_VERSION"]
+__all__ = ["AF", "System", "AF_SDK_VERSION"]
 
 logger = logging.getLogger(__name__)
 
-pythonnet.load()  # Required for the import of System in other modules
+# pragma pylint: disable=import-outside-toplevel
 
 
 def __fallback():
@@ -20,9 +18,11 @@ def __fallback():
 
     warnings.warn("Can't import the PI AF SDK, running in test mode", ImportWarning)
 
-    from ._typing import AF, AF_SDK_VERSION
+    from ._typing import AF as _af
+    from ._typing import AF_SDK_VERSION as _AF_SDK_version
+    from ._typing import dotnet as _System
 
-    return AF, AF_SDK_VERSION
+    return _af, _System, _AF_SDK_version
 
 
 if (
@@ -30,7 +30,7 @@ if (
     or os.getenv("TF_BUILD", "false").lower() == "true"
     or os.getenv("READTHEDOCS", "false").lower() == "true"
 ):
-    _af, _AF_SDK_version = __fallback()
+    _af, _System, _AF_SDK_version = __fallback()
 else:
     import clr
 
@@ -57,7 +57,8 @@ else:
 
     clr.AddReference("OSIsoft.AFSDK")  # type: ignore ; pylint: disable=no-member
 
-    from OSIsoft import AF as _af  # type: ignore ; pylint: wrong-import-position
+    import System as _System  # type: ignore
+    from OSIsoft import AF as _af  # type: ignore
 
     _AF_SDK_version: str = _af.PISystems().Version  # type: ignore ; pylint: disable=no-member
     print("OSIsoft(r) AF SDK Version: {}".format(_AF_SDK_version))
@@ -66,7 +67,8 @@ else:
 if typing.TYPE_CHECKING:
     # This branch is separate from previous one as otherwise no typechecking takes place
     # on the main logic.
-    _af, _AF_SDK_version = __fallback()
+    _af, _System, _AF_SDK_version = __fallback()
 
 AF = _af
+System = _System
 AF_SDK_VERSION = _AF_SDK_version

--- a/PIconnect/PI.py
+++ b/PIconnect/PI.py
@@ -4,10 +4,10 @@
 import warnings
 from typing import Any, Dict, List, Optional, Union, cast
 
-import PIconnect._typing.Generic as _dotNetGeneric
 import PIconnect.PIPoint as PIPoint_
 from PIconnect import AF, PIConsts
 from PIconnect._utils import InitialisationWarning
+from PIconnect.AFSDK import System
 
 __all__ = ["PIServer", "PIPoint"]
 
@@ -16,12 +16,11 @@ PIPoint = PIPoint_.PIPoint
 
 def _lookup_servers() -> Dict[str, AF.PI.PIServer]:
     servers: Dict[str, AF.PI.PIServer] = {}
-    from System import Exception as dotNetException  # type: ignore
 
     for server in AF.PI.PIServers():
         try:
             servers[server.Name] = server
-        except (Exception, dotNetException) as e:  # type: ignore
+        except (Exception, System.Exception) as e:  # type: ignore
             warnings.warn(
                 f"Failed loading server data for {server.Name} "
                 f"with error {type(cast(Exception, e)).__qualname__}",
@@ -97,27 +96,23 @@ class PIServer(object):  # pylint: disable=useless-object-inheritance
                 "A domain can only specified together with a username and password."
             )
         if username:
-            from System.Net import NetworkCredential  # type: ignore
-            from System.Security import SecureString  # type: ignore
-
-            secure_pass = cast(_dotNetGeneric.SecureString, SecureString())
+            secure_pass = System.Security.SecureString()
             if password is not None:
                 for c in password:
                     secure_pass.AppendChar(c)
-            cred = [username, secure_pass] + ([domain] if domain else [])
+            cred = (username, secure_pass) + ((domain,) if domain else ())
             self._credentials = (
-                cast(_dotNetGeneric.NetworkCredential, NetworkCredential(*cred)),
+                System.Net.NetworkCredential(cred[0], cred[1], *cred[2:]),
                 AF.PI.PIAuthenticationMode(int(authentication_mode)),
             )
         else:
             self._credentials = None
 
         if timeout:
-            from System import TimeSpan  # type: ignore
 
             # System.TimeSpan(hours, minutes, seconds)
-            self.connection.ConnectionInfo.OperationTimeOut = cast(
-                _dotNetGeneric.TimeSpan, TimeSpan(0, 0, timeout)
+            self.connection.ConnectionInfo.OperationTimeOut = System.TimeSpan(
+                0, 0, timeout
             )
 
     def __enter__(self):

--- a/PIconnect/PI.py
+++ b/PIconnect/PI.py
@@ -109,7 +109,6 @@ class PIServer(object):  # pylint: disable=useless-object-inheritance
             self._credentials = None
 
         if timeout:
-
             # System.TimeSpan(hours, minutes, seconds)
             self.connection.ConnectionInfo.OperationTimeOut = System.TimeSpan(
                 0, 0, timeout

--- a/PIconnect/PIAF.py
+++ b/PIconnect/PIAF.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Any, Dict, Optional, Union, cast, List
 
 from PIconnect import AF, PIAFBase, PIConsts, _time
+from PIconnect.AFSDK import System
 from PIconnect._utils import InitialisationWarning
 from PIconnect import PIAFAttribute
 
@@ -23,8 +24,6 @@ ServerSpec = Dict[str, Union[AF.PISystem, Dict[str, AF.AFDatabase]]]
 
 
 def _lookup_servers() -> Dict[str, ServerSpec]:
-    from System import Exception as dotNetException  # type: ignore
-
     servers: Dict[str, PIAFServer] = {}
     for s in AF.PISystems():
         try:
@@ -32,13 +31,13 @@ def _lookup_servers() -> Dict[str, ServerSpec]:
             for d in s.Databases:
                 try:
                     server.databases[d.Name] = d
-                except (Exception, dotNetException) as e:  # type: ignore
+                except (Exception, System.Exception) as e:  # type: ignore
                     warnings.warn(
                         f"Failed loading database data for {d.Name} on {s.Name} "
                         f"with error {type(cast(Exception, e)).__qualname__}",
                         InitialisationWarning,
                     )
-        except (Exception, dotNetException) as e:  # type: ignore
+        except (Exception, System.Exception) as e:  # type: ignore
             warnings.warn(
                 f"Failed loading server data for {s.Name} "
                 f"with error {type(cast(Exception, e)).__qualname__}",
@@ -151,7 +150,7 @@ class PIAFDatabase(object):
         """Return a descendant of the database from an exact path."""
         return PIAFElement(self.database.Elements.get_Item(path))
 
-    def search(self, query: Union[str, List[str]]) -> "PIAFAttribute":
+    def search(self, query: Union[str, List[str]]) -> List[PIAFAttribute.PIAFAttribute]:
         """return a list of PIAFAttributes directly from a list of element|attribute path strings
 
             like this:
@@ -160,7 +159,7 @@ class PIAFDatabase(object):
         "BaseElement/childElement/childElement|Attribute|ChildAttribute|ChildAttribute")
 
         """
-        attributelist = []
+        attributelist: List[PIAFAttribute.PIAFAttribute] = []
         if isinstance(query, List):
             return [y for x in query for y in self.search(x)]
         if "|" in query:

--- a/PIconnect/_time.py
+++ b/PIconnect/_time.py
@@ -6,8 +6,8 @@ from typing import Union
 import pytz
 
 from PIconnect import AF, PIConfig
+from PIconnect.AFSDK import System
 
-from ._typing import Time
 
 TimeLike = Union[str, datetime.datetime]
 
@@ -51,7 +51,7 @@ def to_af_time(time: TimeLike) -> AF.Time.AFTime:
     return AF.Time.AFTime(time)
 
 
-def timestamp_to_index(timestamp: Time.DateTime) -> datetime.datetime:
+def timestamp_to_index(timestamp: System.DateTime) -> datetime.datetime:
     """Convert AFTime object to datetime in local timezone.
 
     Args:

--- a/PIconnect/_typing/PI.py
+++ b/PIconnect/_typing/PI.py
@@ -2,7 +2,7 @@
 import enum
 from typing import Iterable, Iterator, List, Optional, Union
 
-from . import Data, Generic, Time, _values
+from . import Data, Generic, Time, _values, dotnet as System
 
 __all__ = ["PIPoint", "PIServer", "PIServers"]
 
@@ -11,7 +11,7 @@ class PIConnectionInfo:
     """Mock class of the AF.PI.PIConnectionInfo class"""
 
     def __init__(self) -> None:
-        self.OperationTimeOut: Generic.TimeSpan
+        self.OperationTimeOut: System.TimeSpan
 
 
 class PIAuthenticationMode(enum.IntEnum):
@@ -31,7 +31,7 @@ class PIServer:
 
     def Connect(
         self,
-        retry: Union[bool, Generic.NetworkCredential],
+        retry: Union[bool, System.Net.NetworkCredential],
         authentication_mode: Optional[PIAuthenticationMode] = None,
     ) -> None:
         """Stub for connecting to test server"""

--- a/PIconnect/_typing/Time.py
+++ b/PIconnect/_typing/Time.py
@@ -1,25 +1,14 @@
-from typing import Optional, Protocol
-
-
-class DateTime(Protocol):
-    """Mock for System.DateTime"""
-
-    Year: int
-    Month: int
-    Day: int
-    Hour: int
-    Minute: int
-    Second: int
-    Millisecond: int
+from typing import Optional
+from . import dotnet as System
 
 
 class AFTime:
     """Mock class of the AF.Time.AFTime class"""
 
     def __init__(self, time: str) -> None:
-        self.UtcTime: DateTime
+        self.UtcTime: System.DateTime
 
-    Now: DateTime
+    Now: System.DateTime
 
 
 class AFTimeRange:

--- a/PIconnect/_typing/dotnet/Net.py
+++ b/PIconnect/_typing/dotnet/Net.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from .Security import SecureString
+
+
+class NetworkCredential:
+    def __init__(
+        self, username: str, password: SecureString, domain: Optional[str] = None
+    ) -> None:
+        self.UserName = username
+        self.Password = password
+        self.Domain = domain

--- a/PIconnect/_typing/dotnet/Security.py
+++ b/PIconnect/_typing/dotnet/Security.py
@@ -1,0 +1,6 @@
+class SecureString:
+    def __init__(self) -> None:
+        self.Value = ""
+
+    def AppendChar(self, char: str) -> None:
+        self.Value += char

--- a/PIconnect/_typing/dotnet/__init__.py
+++ b/PIconnect/_typing/dotnet/__init__.py
@@ -1,0 +1,27 @@
+from typing import Protocol
+from . import Net, Security
+
+__all__ = ["Net", "Security", "Exception", "TimeSpan"]
+
+
+class Exception:
+    pass
+
+
+class TimeSpan:
+    def __init__(self, /, hours: int, minutes: int, seconds: int) -> None:
+        self.Hours = hours
+        self.Minutes = minutes
+        self.Seconds = seconds
+
+
+class DateTime(Protocol):
+    """Mock for System.DateTime"""
+
+    Year: int
+    Month: int
+    Day: int
+    Hour: int
+    Minute: int
+    Second: int
+    Millisecond: int


### PR DESCRIPTION
Since the .NET Framework might not be available on build servers a mock framework is imported during checking.