### PR TITLE
recorded_values_by_count

### DIFF
--- a/PIconnect/PIPoint.py
+++ b/PIconnect/PIPoint.py
@@ -176,3 +176,15 @@ class PIPoint(PIData.PISeriesContainer):
         buffer_mode: AF.Data.AFBufferOption,
     ) -> None:
         return self.pi_point.UpdateValue(value, update_mode, buffer_mode)
+
+    # Added _update_recorded_values_by_count
+    def _recorded_values_by_count(
+        self,
+        startTime: AF.Time.AFTime,
+        count: int,
+        forward: bool,
+        boundaryType: AF.Data.AFBoundaryType,
+        filterExpression: str,
+        includeFilteredValues: bool
+    ) -> AF.Asset.AFValues:
+        return self.pi_point.RecordedValuesByCount(startTime, count, forward, boundaryType, filterExpression, includeFilteredValues)

--- a/PIconnect/_typing/PI.py
+++ b/PIconnect/_typing/PI.py
@@ -153,3 +153,14 @@ class PIPoint:
         /,
     ) -> None:
         pass
+
+    @staticmethod
+    def RecordedValuesByCount(
+        start_time: Time.AFTime,
+        count: int,
+        forward: bool,
+        boundaryType: Data.AFBoundaryType,
+        filterExpression: str,
+        includeFilteredValues: bool
+    ) -> _values.AFValues:
+        return _values.AFValues()


### PR DESCRIPTION
Added recorded_values_by_count function utilizing full PI API - allows user to pull specified number of values, either forward or backward, using a filtering expression.  I use this frequently in excel to find the time when a totalizer point equaled a value of interest.